### PR TITLE
Added .gitattributes file to fix build on windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Enforce LF line endings for cli js file so windows build output can also be run on *nix systems
+# This overwrite the core.autocrlf settings for that file so git checkout doesn't produce a CRLF version on windows
+server/bin/yakjs-cli.js text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
Added a `.gitattributes` file ensuring that the `yakjs-cli.js` file will contain LF line endings even when checkout out on windows with `core.autocrlf=true` so that builds originating from windows machine can be run on *nix machines.
I also did the same for `*.sh` files while i was at it although that has no direct impact on published builds.

Issue:
The current yak-js node module cannot be run on non-windows machines when installed globally because the published files contain CRLF line endings:
```sh
Martins-MacBook-Pro:Documents martin$ sudo npm install -g yakjs
/usr/local/bin/yakjs -> /usr/local/lib/node_modules/yakjs/bin/yakjs-cli.js
/usr/local/lib
Martins-MacBook-Pro:Documents martin$ yakjs 
env: node\r: No such file or directory
```

Note:
After updating a working copy, the file must be removed from disk and checked out again as there is no actual change to the js-file itself in the repository (and `git checkout-index -fa` will also ignore it).
Alternatively, clone the repository again.